### PR TITLE
Support Guzzle 6 or 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=7.2.0",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.0 | ^7.0",
     "tightenco/collect": "^6.0",
     "psr/cache": "^1.0",
     "bentools/guzzle-throttle-middleware": "^0.4.0",


### PR DESCRIPTION
This is the same as https://github.com/Weble/ZohoBooksApi/pull/54 but I realized that project depends on this one which only supports 6.