### PR TITLE
Handle Expired tokens in cache

### DIFF
--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -236,8 +236,7 @@ class OAuthClient
         if ($this->hasCache()) {
             try {
                 $cachedAccessToken = $this->cache->getItem($this->cachePrefix . 'access_token');
-
-				if ($cachedAccessToken->isHit()) {
+		if ($cachedAccessToken->isHit()) {
                     /** @var \Asad\OAuth2\Client\AccessToken\ZohoAccessToken */
                     $accessToken = $cachedAccessToken->get();
                     if ($accessToken->hasExpired()) {

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -239,7 +239,8 @@ class OAuthClient
                 if ($cachedAccessToken->isHit()) {
                     /** @var \Asad\OAuth2\Client\AccessToken\ZohoAccessToken */
                     $accessToken = $cachedAccessToken->get();
-                    if ($accessToken->hasExpired()) {
+                    if (!$accessToken->hasExpired()) {
+                        $this->accessToken = $accessToken;
                         return $this->accessToken->getToken();
                     }
                 }

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -237,9 +237,12 @@ class OAuthClient
             try {
                 $cachedAccessToken = $this->cache->getItem($this->cachePrefix . 'access_token');
 
-                if ($cachedAccessToken->isHit()) {
-                    $this->accessToken = $cachedAccessToken->get();
-                    return $this->accessToken->getToken();
+				if ($cachedAccessToken->isHit()) {
+                    /** @var \Asad\OAuth2\Client\AccessToken\ZohoAccessToken */
+                    $accessToken = $cachedAccessToken->get();
+                    if ($accessToken->hasExpired()) {
+                        return $this->accessToken->getToken();
+                    }
                 }
             } catch (InvalidArgumentException $e) {
             }

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -236,7 +236,7 @@ class OAuthClient
         if ($this->hasCache()) {
             try {
                 $cachedAccessToken = $this->cache->getItem($this->cachePrefix . 'access_token');
-		if ($cachedAccessToken->isHit()) {
+                if ($cachedAccessToken->isHit()) {
                     /** @var \Asad\OAuth2\Client\AccessToken\ZohoAccessToken */
                     $accessToken = $cachedAccessToken->get();
                     if ($accessToken->hasExpired()) {


### PR DESCRIPTION
Handle not returning expired tokens from cache

This is happening in caches that don't support expiring (like Filesystem which im using for testing)