### PR TITLE
Add scope on refreshAccessToken()

### DIFF
--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -376,6 +376,7 @@ class OAuthClient
             $grant = new RefreshToken();
             $this->accessToken = $this->provider->getAccessToken($grant, [
                 'refresh_token' => $this->getRefreshToken(),
+                'scope' => $this->scopes
             ]);
         } catch (IdentityProviderException $e) {
             $message = $e->getMessage();


### PR DESCRIPTION
Without adding scope refreshAccessToken is considering default scope resulting in invalid_scope response from the API